### PR TITLE
fix: isolate scripts in IIFEs and correct day-of countdown rollover

### DIFF
--- a/christmasCountdown.js
+++ b/christmasCountdown.js
@@ -1,7 +1,12 @@
 (function () {
   'use strict';
 
-  function tick() {
+  if (window.__rfChristmasCountdown) return;
+  window.__rfChristmasCountdown = true;
+
+  let elDays, elHours, elMinutes, elSeconds;
+
+  function update() {
     let now = new Date();
     let year = now.getFullYear();
     let evenDate = new Date(year, 11, 25);
@@ -28,21 +33,34 @@
     m = m < 10 ? '0' + m : m;
     s = s < 10 ? '0' + s : s;
 
-    if (document.querySelector('#to-christmas-days') != null) {
-      document.querySelector('#to-christmas-days').textContent = d;
-    }
-    if (document.querySelector('#to-christmas-hours') != null) {
-      document.querySelector('#to-christmas-hours').textContent = h;
-    }
-    if (document.querySelector('#to-christmas-minutes') != null) {
-      document.querySelector('#to-christmas-minutes').textContent = m;
-    }
-    if (document.querySelector('#to-christmas-seconds') != null) {
-      document.querySelector('#to-christmas-seconds').textContent = s;
-    }
-
-    setTimeout(tick, 1000);
+    if (elDays) elDays.textContent = d;
+    if (elHours) elHours.textContent = h;
+    if (elMinutes) elMinutes.textContent = m;
+    if (elSeconds) elSeconds.textContent = s;
   }
 
-  tick();
+  function loop() {
+    if (!document.hidden) update();
+    setTimeout(loop, 1000);
+  }
+
+  function start() {
+    elDays = document.querySelector('#to-christmas-days');
+    elHours = document.querySelector('#to-christmas-hours');
+    elMinutes = document.querySelector('#to-christmas-minutes');
+    elSeconds = document.querySelector('#to-christmas-seconds');
+
+    document.addEventListener('visibilitychange', () => {
+      if (!document.hidden) update();
+    });
+
+    update();
+    loop();
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', start);
+  } else {
+    start();
+  }
 })();

--- a/christmasCountdown.js
+++ b/christmasCountdown.js
@@ -1,44 +1,48 @@
-function countdown() {
-  let now = new Date();
-  let year = now.getFullYear();
-  let evenDate = new Date(year, 11, 25);
+(function () {
+  'use strict';
 
-  // If Christmas has passed, count down to next year
-  if (now > evenDate) {
-    evenDate = new Date(year + 1, 11, 25);
+  function tick() {
+    let now = new Date();
+    let year = now.getFullYear();
+    let evenDate = new Date(year, 11, 25);
+
+    // Roll over to next year only after Christmas Day has fully passed,
+    // so visitors on Dec 25 see 0d 00:00:00 instead of ~365 days.
+    if (now > new Date(year, 11, 26)) {
+      evenDate = new Date(year + 1, 11, 25);
+    }
+
+    let remTime = evenDate.getTime() - now.getTime();
+    if (remTime < 0) remTime = 0;
+
+    let s = Math.floor(remTime / 1000);
+    let m = Math.floor(s / 60);
+    let h = Math.floor(m / 60);
+    let d = Math.floor(h / 24);
+
+    h %= 24;
+    m %= 60;
+    s %= 60;
+
+    h = h < 10 ? '0' + h : h;
+    m = m < 10 ? '0' + m : m;
+    s = s < 10 ? '0' + s : s;
+
+    if (document.querySelector('#to-christmas-days') != null) {
+      document.querySelector('#to-christmas-days').textContent = d;
+    }
+    if (document.querySelector('#to-christmas-hours') != null) {
+      document.querySelector('#to-christmas-hours').textContent = h;
+    }
+    if (document.querySelector('#to-christmas-minutes') != null) {
+      document.querySelector('#to-christmas-minutes').textContent = m;
+    }
+    if (document.querySelector('#to-christmas-seconds') != null) {
+      document.querySelector('#to-christmas-seconds').textContent = s;
+    }
+
+    setTimeout(tick, 1000);
   }
 
-  let actualTime = now.getTime();
-  let eventTime = evenDate.getTime();
-  let remTime = eventTime - actualTime;
-
-  let s = Math.floor(remTime / 1000);
-  let m = Math.floor(s / 60);
-  let h = Math.floor(m / 60);
-  let d = Math.floor(h / 24);
-
-  h %= 24;
-  m %= 60;
-  s %= 60;
-
-  h = h < 10 ? '0' + h : h;
-  m = m < 10 ? '0' + m : m;
-  s = s < 10 ? '0' + s : s;
-
-  if(document.querySelector('#to-christmas-days') != null) {
-    document.querySelector('#to-christmas-days').textContent = d;
-  }
-  if(document.querySelector('#to-christmas-hours') != null) {
-    document.querySelector('#to-christmas-hours').textContent = h;
-  }
-  if(document.querySelector('#to-christmas-minutes') != null) {
-    document.querySelector('#to-christmas-minutes').textContent = m;
-  }
-  if(document.querySelector('#to-christmas-seconds') != null) {
-    document.querySelector('#to-christmas-seconds').textContent = s;
-  }
-
-  setTimeout(countdown, 1000)
-};
-
-countdown();
+  tick();
+})();

--- a/customCountdown.js
+++ b/customCountdown.js
@@ -1,77 +1,79 @@
-function customCountdown() {
-  let container = document.querySelector('#custom-countdown');
-  if (container == null) {
-    return;
-  }
+(function () {
+  'use strict';
 
-  let targetValue = container.getAttribute('data-target');
-  if (targetValue == null) {
-    return;
-  }
-
-  let now = new Date();
-  let evenDate;
-
-  // Check if it's a time-only format (HH:MM or HH:MM:SS)
-  if (/^\d{1,2}:\d{2}(:\d{2})?$/.test(targetValue)) {
-    // Daily recurring time
-    let timeParts = targetValue.split(':');
-    let hours = parseInt(timeParts[0], 10);
-    let minutes = parseInt(timeParts[1], 10);
-    let seconds = timeParts[2] ? parseInt(timeParts[2], 10) : 0;
-
-    evenDate = new Date(now.getFullYear(), now.getMonth(), now.getDate(), hours, minutes, seconds);
-
-    // If the time has passed today, set it for tomorrow
-    if (now >= evenDate) {
-      evenDate.setDate(evenDate.getDate() + 1);
-    }
-  } else {
-    // Specific date/time format
-    evenDate = new Date(targetValue);
-
-    // If invalid date, exit
-    if (isNaN(evenDate.getTime())) {
+  function tick() {
+    let container = document.querySelector('#custom-countdown');
+    if (container == null) {
       return;
     }
+
+    let targetValue = container.getAttribute('data-target');
+    if (targetValue == null) {
+      return;
+    }
+
+    let now = new Date();
+    let evenDate;
+
+    // Check if it's a time-only format (HH:MM or HH:MM:SS)
+    if (/^\d{1,2}:\d{2}(:\d{2})?$/.test(targetValue)) {
+      // Daily recurring time
+      let timeParts = targetValue.split(':');
+      let hours = parseInt(timeParts[0], 10);
+      let minutes = parseInt(timeParts[1], 10);
+      let seconds = timeParts[2] ? parseInt(timeParts[2], 10) : 0;
+
+      evenDate = new Date(now.getFullYear(), now.getMonth(), now.getDate(), hours, minutes, seconds);
+
+      // If the time has passed today, set it for tomorrow
+      if (now >= evenDate) {
+        evenDate.setDate(evenDate.getDate() + 1);
+      }
+    } else {
+      // Specific date/time format
+      evenDate = new Date(targetValue);
+
+      // If invalid date, exit
+      if (isNaN(evenDate.getTime())) {
+        return;
+      }
+    }
+
+    let remTime = evenDate.getTime() - now.getTime();
+
+    // If the target has passed (for non-recurring), show zeros
+    if (remTime < 0) {
+      remTime = 0;
+    }
+
+    let s = Math.floor(remTime / 1000);
+    let m = Math.floor(s / 60);
+    let h = Math.floor(m / 60);
+    let d = Math.floor(h / 24);
+
+    h %= 24;
+    m %= 60;
+    s %= 60;
+
+    h = h < 10 ? '0' + h : h;
+    m = m < 10 ? '0' + m : m;
+    s = s < 10 ? '0' + s : s;
+
+    if (document.querySelector('#custom-countdown-days') != null) {
+      document.querySelector('#custom-countdown-days').textContent = d;
+    }
+    if (document.querySelector('#custom-countdown-hours') != null) {
+      document.querySelector('#custom-countdown-hours').textContent = h;
+    }
+    if (document.querySelector('#custom-countdown-minutes') != null) {
+      document.querySelector('#custom-countdown-minutes').textContent = m;
+    }
+    if (document.querySelector('#custom-countdown-seconds') != null) {
+      document.querySelector('#custom-countdown-seconds').textContent = s;
+    }
+
+    setTimeout(tick, 1000);
   }
 
-  let actualTime = now.getTime();
-  let eventTime = evenDate.getTime();
-  let remTime = eventTime - actualTime;
-
-  // If the target has passed (for non-recurring), show zeros
-  if (remTime < 0) {
-    remTime = 0;
-  }
-
-  let s = Math.floor(remTime / 1000);
-  let m = Math.floor(s / 60);
-  let h = Math.floor(m / 60);
-  let d = Math.floor(h / 24);
-
-  h %= 24;
-  m %= 60;
-  s %= 60;
-
-  h = h < 10 ? '0' + h : h;
-  m = m < 10 ? '0' + m : m;
-  s = s < 10 ? '0' + s : s;
-
-  if (document.querySelector('#custom-countdown-days') != null) {
-    document.querySelector('#custom-countdown-days').textContent = d;
-  }
-  if (document.querySelector('#custom-countdown-hours') != null) {
-    document.querySelector('#custom-countdown-hours').textContent = h;
-  }
-  if (document.querySelector('#custom-countdown-minutes') != null) {
-    document.querySelector('#custom-countdown-minutes').textContent = m;
-  }
-  if (document.querySelector('#custom-countdown-seconds') != null) {
-    document.querySelector('#custom-countdown-seconds').textContent = s;
-  }
-
-  setTimeout(customCountdown, 1000);
-}
-
-customCountdown();
+  tick();
+})();

--- a/customCountdown.js
+++ b/customCountdown.js
@@ -1,14 +1,19 @@
 (function () {
   'use strict';
 
-  function tick() {
-    let container = document.querySelector('#custom-countdown');
-    if (container == null) {
-      return;
-    }
+  if (window.__rfCustomCountdown) return;
+  window.__rfCustomCountdown = true;
 
-    let targetValue = container.getAttribute('data-target');
+  let container, elDays, elHours, elMinutes, elSeconds;
+  let warned = false;
+
+  function update() {
+    const targetValue = container.getAttribute('data-target');
     if (targetValue == null) {
+      if (!warned) {
+        console.warn('[remote-falcon] custom-countdown: missing data-target attribute');
+        warned = true;
+      }
       return;
     }
 
@@ -33,18 +38,19 @@
       // Specific date/time format
       evenDate = new Date(targetValue);
 
-      // If invalid date, exit
       if (isNaN(evenDate.getTime())) {
+        if (!warned) {
+          console.warn('[remote-falcon] custom-countdown: invalid data-target', targetValue);
+          warned = true;
+        }
         return;
       }
     }
 
-    let remTime = evenDate.getTime() - now.getTime();
+    warned = false;
 
-    // If the target has passed (for non-recurring), show zeros
-    if (remTime < 0) {
-      remTime = 0;
-    }
+    let remTime = evenDate.getTime() - now.getTime();
+    if (remTime < 0) remTime = 0;
 
     let s = Math.floor(remTime / 1000);
     let m = Math.floor(s / 60);
@@ -59,21 +65,40 @@
     m = m < 10 ? '0' + m : m;
     s = s < 10 ? '0' + s : s;
 
-    if (document.querySelector('#custom-countdown-days') != null) {
-      document.querySelector('#custom-countdown-days').textContent = d;
-    }
-    if (document.querySelector('#custom-countdown-hours') != null) {
-      document.querySelector('#custom-countdown-hours').textContent = h;
-    }
-    if (document.querySelector('#custom-countdown-minutes') != null) {
-      document.querySelector('#custom-countdown-minutes').textContent = m;
-    }
-    if (document.querySelector('#custom-countdown-seconds') != null) {
-      document.querySelector('#custom-countdown-seconds').textContent = s;
-    }
-
-    setTimeout(tick, 1000);
+    if (elDays) elDays.textContent = d;
+    if (elHours) elHours.textContent = h;
+    if (elMinutes) elMinutes.textContent = m;
+    if (elSeconds) elSeconds.textContent = s;
   }
 
-  tick();
+  function loop() {
+    if (!document.hidden) update();
+    setTimeout(loop, 1000);
+  }
+
+  function start() {
+    container = document.querySelector('#custom-countdown');
+    if (container == null) {
+      console.warn('[remote-falcon] custom-countdown: missing #custom-countdown container');
+      return;
+    }
+
+    elDays = document.querySelector('#custom-countdown-days');
+    elHours = document.querySelector('#custom-countdown-hours');
+    elMinutes = document.querySelector('#custom-countdown-minutes');
+    elSeconds = document.querySelector('#custom-countdown-seconds');
+
+    document.addEventListener('visibilitychange', () => {
+      if (!document.hidden) update();
+    });
+
+    update();
+    loop();
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', start);
+  } else {
+    start();
+  }
 })();

--- a/dynamicMenu.js
+++ b/dynamicMenu.js
@@ -1,47 +1,49 @@
-   "use strict"; 
-    const rf_menu_body = document.body;
-    const rf_menu = rf_menu_body.querySelector(".rf_menu");
-    if(rf_menu)
-    {
-        const menuItems = rf_menu.querySelectorAll(".rf_menu__item");
-    	const menuBorder = rf_menu.querySelector(".rf_menu__border");
-        let activeItem = rf_menu.querySelector(".active");
-    	
-        function clickItem(item,index) {
-            if (activeItem === item) return;
-            
-            if (activeItem) {
-                activeItem.classList.remove("active");
-            }
-            
-            item.classList.add("active");
-            activeItem = item;
-    		showTab(index);
-            offsetMenuBorder(activeItem, menuBorder);
-        }
-        
-        function showTab(index) {
-                const bodies = document.querySelectorAll('.content__body');
-                bodies.forEach((rf_menu_body, i) => {
-                    rf_menu_body.classList.toggle('active', i === index);
-                });
-            }
-    
-    
-    
-        function offsetMenuBorder(element, menuBorder) {
-            const offsetActiveItem = element.getBoundingClientRect();
-            const left = Math.floor(offsetActiveItem.left - rf_menu.offsetLeft - (menuBorder.offsetWidth - offsetActiveItem.width) / 2) + "px";
-            menuBorder.style.transform = `translate3d(${left}, 0 , 0)`;
-        }
-    
-        offsetMenuBorder(activeItem, menuBorder);
-    
-        menuItems.forEach((item,index) => {
-            item.addEventListener("click", () => clickItem(item,index));
-        });
-    	window.addEventListener("resize", () => {
-            offsetMenuBorder(activeItem, menuBorder);
-            rf_menu.style.setProperty("--timeOut", "none");
-        });
+(function () {
+  'use strict';
+
+  const rf_menu = document.body && document.body.querySelector(".rf_menu");
+  if (!rf_menu) return;
+
+  const menuItems = rf_menu.querySelectorAll(".rf_menu__item");
+  const menuBorder = rf_menu.querySelector(".rf_menu__border");
+  let activeItem = rf_menu.querySelector(".active");
+
+  if (!activeItem || !menuBorder) return;
+
+  function clickItem(item, index) {
+    if (activeItem === item) return;
+
+    if (activeItem) {
+      activeItem.classList.remove("active");
     }
+
+    item.classList.add("active");
+    activeItem = item;
+    showTab(index);
+    offsetMenuBorder(activeItem, menuBorder);
+  }
+
+  function showTab(index) {
+    const bodies = document.querySelectorAll('.content__body');
+    bodies.forEach((body, i) => {
+      body.classList.toggle('active', i === index);
+    });
+  }
+
+  function offsetMenuBorder(element, menuBorder) {
+    const offsetActiveItem = element.getBoundingClientRect();
+    const left = Math.floor(offsetActiveItem.left - rf_menu.offsetLeft - (menuBorder.offsetWidth - offsetActiveItem.width) / 2) + "px";
+    menuBorder.style.transform = `translate3d(${left}, 0 , 0)`;
+  }
+
+  offsetMenuBorder(activeItem, menuBorder);
+
+  menuItems.forEach((item, index) => {
+    item.addEventListener("click", () => clickItem(item, index));
+  });
+
+  window.addEventListener("resize", () => {
+    offsetMenuBorder(activeItem, menuBorder);
+    rf_menu.style.setProperty("--timeOut", "none");
+  });
+})();

--- a/dynamicMenu.js
+++ b/dynamicMenu.js
@@ -1,49 +1,65 @@
 (function () {
   'use strict';
 
-  const rf_menu = document.body && document.body.querySelector(".rf_menu");
-  if (!rf_menu) return;
+  if (window.__rfDynamicMenu) return;
+  window.__rfDynamicMenu = true;
 
-  const menuItems = rf_menu.querySelectorAll(".rf_menu__item");
-  const menuBorder = rf_menu.querySelector(".rf_menu__border");
-  let activeItem = rf_menu.querySelector(".active");
+  function start() {
+    const rf_menu = document.body.querySelector(".rf_menu");
+    if (!rf_menu) return;
 
-  if (!activeItem || !menuBorder) return;
+    const menuItems = rf_menu.querySelectorAll(".rf_menu__item");
+    const menuBorder = rf_menu.querySelector(".rf_menu__border");
+    let activeItem = rf_menu.querySelector(".active");
 
-  function clickItem(item, index) {
-    if (activeItem === item) return;
+    if (!activeItem || !menuBorder) return;
 
-    if (activeItem) {
-      activeItem.classList.remove("active");
+    function clickItem(item, index) {
+      if (activeItem === item) return;
+
+      if (activeItem) {
+        activeItem.classList.remove("active");
+      }
+
+      item.classList.add("active");
+      activeItem = item;
+      showTab(index);
+      offsetMenuBorder(activeItem, menuBorder);
     }
 
-    item.classList.add("active");
-    activeItem = item;
-    showTab(index);
-    offsetMenuBorder(activeItem, menuBorder);
-  }
+    function showTab(index) {
+      const bodies = document.querySelectorAll('.content__body');
+      bodies.forEach((body, i) => {
+        body.classList.toggle('active', i === index);
+      });
+    }
 
-  function showTab(index) {
-    const bodies = document.querySelectorAll('.content__body');
-    bodies.forEach((body, i) => {
-      body.classList.toggle('active', i === index);
+    function offsetMenuBorder(element, menuBorder) {
+      const offsetActiveItem = element.getBoundingClientRect();
+      const left = Math.floor(offsetActiveItem.left - rf_menu.offsetLeft - (menuBorder.offsetWidth - offsetActiveItem.width) / 2) + "px";
+      menuBorder.style.transform = `translate3d(${left}, 0 , 0)`;
+    }
+
+    offsetMenuBorder(activeItem, menuBorder);
+
+    menuItems.forEach((item, index) => {
+      item.addEventListener("click", () => clickItem(item, index));
+    });
+
+    let resizeRaf = 0;
+    window.addEventListener("resize", () => {
+      if (resizeRaf) return;
+      resizeRaf = requestAnimationFrame(() => {
+        resizeRaf = 0;
+        offsetMenuBorder(activeItem, menuBorder);
+        rf_menu.style.setProperty("--timeOut", "none");
+      });
     });
   }
 
-  function offsetMenuBorder(element, menuBorder) {
-    const offsetActiveItem = element.getBoundingClientRect();
-    const left = Math.floor(offsetActiveItem.left - rf_menu.offsetLeft - (menuBorder.offsetWidth - offsetActiveItem.width) / 2) + "px";
-    menuBorder.style.transform = `translate3d(${left}, 0 , 0)`;
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', start);
+  } else {
+    start();
   }
-
-  offsetMenuBorder(activeItem, menuBorder);
-
-  menuItems.forEach((item, index) => {
-    item.addEventListener("click", () => clickItem(item, index));
-  });
-
-  window.addEventListener("resize", () => {
-    offsetMenuBorder(activeItem, menuBorder);
-    rf_menu.style.setProperty("--timeOut", "none");
-  });
 })();

--- a/halloweenCountdown.js
+++ b/halloweenCountdown.js
@@ -1,7 +1,12 @@
 (function () {
   'use strict';
 
-  function tick() {
+  if (window.__rfHalloweenCountdown) return;
+  window.__rfHalloweenCountdown = true;
+
+  let elDays, elHours, elMinutes, elSeconds;
+
+  function update() {
     let now = new Date();
     let year = now.getFullYear();
     let evenDate = new Date(year, 9, 31); // October 31
@@ -28,21 +33,34 @@
     m = m < 10 ? '0' + m : m;
     s = s < 10 ? '0' + s : s;
 
-    if (document.querySelector('#to-halloween-days') != null) {
-      document.querySelector('#to-halloween-days').textContent = d;
-    }
-    if (document.querySelector('#to-halloween-hours') != null) {
-      document.querySelector('#to-halloween-hours').textContent = h;
-    }
-    if (document.querySelector('#to-halloween-minutes') != null) {
-      document.querySelector('#to-halloween-minutes').textContent = m;
-    }
-    if (document.querySelector('#to-halloween-seconds') != null) {
-      document.querySelector('#to-halloween-seconds').textContent = s;
-    }
-
-    setTimeout(tick, 1000);
+    if (elDays) elDays.textContent = d;
+    if (elHours) elHours.textContent = h;
+    if (elMinutes) elMinutes.textContent = m;
+    if (elSeconds) elSeconds.textContent = s;
   }
 
-  tick();
+  function loop() {
+    if (!document.hidden) update();
+    setTimeout(loop, 1000);
+  }
+
+  function start() {
+    elDays = document.querySelector('#to-halloween-days');
+    elHours = document.querySelector('#to-halloween-hours');
+    elMinutes = document.querySelector('#to-halloween-minutes');
+    elSeconds = document.querySelector('#to-halloween-seconds');
+
+    document.addEventListener('visibilitychange', () => {
+      if (!document.hidden) update();
+    });
+
+    update();
+    loop();
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', start);
+  } else {
+    start();
+  }
 })();

--- a/halloweenCountdown.js
+++ b/halloweenCountdown.js
@@ -1,44 +1,48 @@
-function countdown() {
-  let now = new Date();
-  let year = now.getFullYear();
-  let evenDate = new Date(year, 9, 31); // October 31
+(function () {
+  'use strict';
 
-  // If Halloween has passed, count down to next year
-  if (now > evenDate) {
-    evenDate = new Date(year + 1, 9, 31);
+  function tick() {
+    let now = new Date();
+    let year = now.getFullYear();
+    let evenDate = new Date(year, 9, 31); // October 31
+
+    // Roll over to next year only after Halloween has fully passed,
+    // so visitors on Oct 31 (especially trick-or-treat night) see 0d 00:00:00.
+    if (now > new Date(year, 10, 1)) {
+      evenDate = new Date(year + 1, 9, 31);
+    }
+
+    let remTime = evenDate.getTime() - now.getTime();
+    if (remTime < 0) remTime = 0;
+
+    let s = Math.floor(remTime / 1000);
+    let m = Math.floor(s / 60);
+    let h = Math.floor(m / 60);
+    let d = Math.floor(h / 24);
+
+    h %= 24;
+    m %= 60;
+    s %= 60;
+
+    h = h < 10 ? '0' + h : h;
+    m = m < 10 ? '0' + m : m;
+    s = s < 10 ? '0' + s : s;
+
+    if (document.querySelector('#to-halloween-days') != null) {
+      document.querySelector('#to-halloween-days').textContent = d;
+    }
+    if (document.querySelector('#to-halloween-hours') != null) {
+      document.querySelector('#to-halloween-hours').textContent = h;
+    }
+    if (document.querySelector('#to-halloween-minutes') != null) {
+      document.querySelector('#to-halloween-minutes').textContent = m;
+    }
+    if (document.querySelector('#to-halloween-seconds') != null) {
+      document.querySelector('#to-halloween-seconds').textContent = s;
+    }
+
+    setTimeout(tick, 1000);
   }
 
-  let actualTime = now.getTime();
-  let eventTime = evenDate.getTime();
-  let remTime = eventTime - actualTime;
-
-  let s = Math.floor(remTime / 1000);
-  let m = Math.floor(s / 60);
-  let h = Math.floor(m / 60);
-  let d = Math.floor(h / 24);
-
-  h %= 24;
-  m %= 60;
-  s %= 60;
-
-  h = h < 10 ? '0' + h : h;
-  m = m < 10 ? '0' + m : m;
-  s = s < 10 ? '0' + s : s;
-
-  if(document.querySelector('#to-halloween-days') != null) {
-    document.querySelector('#to-halloween-days').textContent = d;
-  }
-  if(document.querySelector('#to-halloween-hours') != null) {
-    document.querySelector('#to-halloween-hours').textContent = h;
-  }
-  if(document.querySelector('#to-halloween-minutes') != null) {
-    document.querySelector('#to-halloween-minutes').textContent = m;
-  }
-  if(document.querySelector('#to-halloween-seconds') != null) {
-    document.querySelector('#to-halloween-seconds').textContent = s;
-  }
-
-  setTimeout(countdown, 1000)
-};
-
-countdown();
+  tick();
+})();

--- a/makeItSnow.js
+++ b/makeItSnow.js
@@ -1,69 +1,78 @@
 // widget by Embed.im (Licenses & Credits: https://app.embed.im/licenses.txt)
-var embedimSnow = document.getElementById("embedim--snow");
-if (!embedimSnow) {
-  let embRand2 = function (min, max) {
+(function () {
+  'use strict';
+
+  function start() {
+    if (document.getElementById("embedim--snow")) return;
+
+    function embRand2(min, max) {
       return Math.floor(Math.random() * (max - min + 1)) + min;
-    },
-    embRandColor2 = function () {
+    }
+    function embRandColor2() {
       var items = [
         "radial-gradient(circle at top left,#dcf2fd,#60b4f2)",
         "#dbf2fd",
         "#d8f8ff",
         "#b8ddfa",
       ];
-      var item = items[Math.floor(Math.random() * items.length)];
-      return item;
-    };
-  var embRand = embRand2,
-    embRandColor = embRandColor2;
-  var embCSS =
-    ".embedim-snow{position: absolute;width: 10px;height: 10px;background: white;border-radius: 50%;margin-top:-10px}";
-  var embHTML = "";
-  for (let i = 1; i < 200; i++) {
-    embHTML += '<i class="embedim-snow"></i>';
-    var rndX = embRand2(0, 1e6) * 1e-4,
-      rndO = embRand2(-1e5, 1e5) * 1e-4,
-      rndT = (embRand2(3, 8) * 10).toFixed(2),
-      rndS = (embRand2(0, 1e4) * 1e-4).toFixed(2);
-    embCSS +=
-      ".embedim-snow:nth-child(" +
-      i +
-      "){background:" +
-      embRandColor2() +
-      ";opacity:" +
-      (embRand2(1, 1e4) * 1e-4).toFixed(2) +
-      ";transform:translate(" +
-      rndX.toFixed(2) +
-      "vw,-10px) scale(" +
-      rndS +
-      ");animation:fall-" +
-      i +
-      " " +
-      embRand2(10, 30) +
-      "s -" +
-      embRand2(0, 30) +
-      "s linear infinite}@keyframes fall-" +
-      i +
-      "{" +
-      rndT +
-      "%{transform:translate(" +
-      (rndX + rndO).toFixed(2) +
-      "vw," +
-      rndT +
-      "vh) scale(" +
-      rndS +
-      ")}to{transform:translate(" +
-      (rndX + rndO / 2).toFixed(2) +
-      "vw, 105vh) scale(" +
-      rndS +
-      ")}}";
+      return items[Math.floor(Math.random() * items.length)];
+    }
+
+    var embCSS =
+      ".embedim-snow{position: absolute;width: 10px;height: 10px;background: white;border-radius: 50%;margin-top:-10px}";
+    var embHTML = "";
+    for (let i = 1; i < 200; i++) {
+      embHTML += '<i class="embedim-snow"></i>';
+      var rndX = embRand2(0, 1e6) * 1e-4,
+        rndO = embRand2(-1e5, 1e5) * 1e-4,
+        rndT = (embRand2(3, 8) * 10).toFixed(2),
+        rndS = (embRand2(0, 1e4) * 1e-4).toFixed(2);
+      embCSS +=
+        ".embedim-snow:nth-child(" +
+        i +
+        "){background:" +
+        embRandColor2() +
+        ";opacity:" +
+        (embRand2(1, 1e4) * 1e-4).toFixed(2) +
+        ";transform:translate(" +
+        rndX.toFixed(2) +
+        "vw,-10px) scale(" +
+        rndS +
+        ");animation:fall-" +
+        i +
+        " " +
+        embRand2(10, 30) +
+        "s -" +
+        embRand2(0, 30) +
+        "s linear infinite}@keyframes fall-" +
+        i +
+        "{" +
+        rndT +
+        "%{transform:translate(" +
+        (rndX + rndO).toFixed(2) +
+        "vw," +
+        rndT +
+        "vh) scale(" +
+        rndS +
+        ")}to{transform:translate(" +
+        (rndX + rndO / 2).toFixed(2) +
+        "vw, 105vh) scale(" +
+        rndS +
+        ")}}";
+    }
+    var embedimSnow = document.createElement("div");
+    embedimSnow.id = "embedim--snow";
+    embedimSnow.innerHTML =
+      "<style>#embedim--snow{position:fixed;left:0;top:0;bottom:0;width:100vw;height:100vh;overflow:hidden;z-index:9999999;pointer-events:none}" +
+      embCSS +
+      "</style>" +
+      embHTML;
+    document.body.appendChild(embedimSnow);
   }
-  embedimSnow = document.createElement("div");
-  embedimSnow.id = "embedim--snow";
-  embedimSnow.innerHTML =
-    "<style>#embedim--snow{position:fixed;left:0;top:0;bottom:0;width:100vw;height:100vh;overflow:hidden;z-index:9999999;pointer-events:none}" +
-    embCSS +
-    "</style>" +
-    embHTML;
-  document.body.appendChild(embedimSnow);
-}
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', start);
+  } else {
+    start();
+  }
+})();

--- a/makeItSnow.js
+++ b/makeItSnow.js
@@ -19,7 +19,7 @@ if (!embedimSnow) {
   var embCSS =
     ".embedim-snow{position: absolute;width: 10px;height: 10px;background: white;border-radius: 50%;margin-top:-10px}";
   var embHTML = "";
-  for (i = 1; i < 200; i++) {
+  for (let i = 1; i < 200; i++) {
     embHTML += '<i class="embedim-snow"></i>';
     var rndX = embRand2(0, 1e6) * 1e-4,
       rndO = embRand2(-1e5, 1e5) * 1e-4,

--- a/thanksgivingCountdown.js
+++ b/thanksgivingCountdown.js
@@ -1,6 +1,11 @@
 (function () {
   'use strict';
 
+  if (window.__rfThanksgivingCountdown) return;
+  window.__rfThanksgivingCountdown = true;
+
+  let elDays, elHours, elMinutes, elSeconds;
+
   // Calculate the 4th Thursday of November for a given year
   function getThanksgiving(year) {
     let november = new Date(year, 10, 1);
@@ -10,7 +15,7 @@
     return new Date(year, 10, fourthThursday);
   }
 
-  function tick() {
+  function update() {
     let now = new Date();
     let year = now.getFullYear();
     let evenDate = getThanksgiving(year);
@@ -38,21 +43,34 @@
     m = m < 10 ? '0' + m : m;
     s = s < 10 ? '0' + s : s;
 
-    if (document.querySelector('#to-thanksgiving-days') != null) {
-      document.querySelector('#to-thanksgiving-days').textContent = d;
-    }
-    if (document.querySelector('#to-thanksgiving-hours') != null) {
-      document.querySelector('#to-thanksgiving-hours').textContent = h;
-    }
-    if (document.querySelector('#to-thanksgiving-minutes') != null) {
-      document.querySelector('#to-thanksgiving-minutes').textContent = m;
-    }
-    if (document.querySelector('#to-thanksgiving-seconds') != null) {
-      document.querySelector('#to-thanksgiving-seconds').textContent = s;
-    }
-
-    setTimeout(tick, 1000);
+    if (elDays) elDays.textContent = d;
+    if (elHours) elHours.textContent = h;
+    if (elMinutes) elMinutes.textContent = m;
+    if (elSeconds) elSeconds.textContent = s;
   }
 
-  tick();
+  function loop() {
+    if (!document.hidden) update();
+    setTimeout(loop, 1000);
+  }
+
+  function start() {
+    elDays = document.querySelector('#to-thanksgiving-days');
+    elHours = document.querySelector('#to-thanksgiving-hours');
+    elMinutes = document.querySelector('#to-thanksgiving-minutes');
+    elSeconds = document.querySelector('#to-thanksgiving-seconds');
+
+    document.addEventListener('visibilitychange', () => {
+      if (!document.hidden) update();
+    });
+
+    update();
+    loop();
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', start);
+  } else {
+    start();
+  }
 })();

--- a/thanksgivingCountdown.js
+++ b/thanksgivingCountdown.js
@@ -1,58 +1,58 @@
-function countdown() {
-  let now = new Date();
-  let year = now.getFullYear();
+(function () {
+  'use strict';
 
-  // Thanksgiving is the 4th Thursday of November
-  let evenDate = getThanksgiving(year);
-
-  // If Thanksgiving has passed, count down to next year
-  if (now > evenDate) {
-    evenDate = getThanksgiving(year + 1);
+  // Calculate the 4th Thursday of November for a given year
+  function getThanksgiving(year) {
+    let november = new Date(year, 10, 1);
+    let dayOfWeek = november.getDay();
+    let firstThursday = 1 + ((4 - dayOfWeek + 7) % 7);
+    let fourthThursday = firstThursday + 21;
+    return new Date(year, 10, fourthThursday);
   }
 
-  let actualTime = now.getTime();
-  let eventTime = evenDate.getTime();
-  let remTime = eventTime - actualTime;
+  function tick() {
+    let now = new Date();
+    let year = now.getFullYear();
+    let evenDate = getThanksgiving(year);
 
-  let s = Math.floor(remTime / 1000);
-  let m = Math.floor(s / 60);
-  let h = Math.floor(m / 60);
-  let d = Math.floor(h / 24);
+    // Roll over only after Thanksgiving Day has fully passed.
+    let dayAfter = new Date(evenDate.getTime());
+    dayAfter.setDate(dayAfter.getDate() + 1);
+    if (now > dayAfter) {
+      evenDate = getThanksgiving(year + 1);
+    }
 
-  h %= 24;
-  m %= 60;
-  s %= 60;
+    let remTime = evenDate.getTime() - now.getTime();
+    if (remTime < 0) remTime = 0;
 
-  h = h < 10 ? '0' + h : h;
-  m = m < 10 ? '0' + m : m;
-  s = s < 10 ? '0' + s : s;
+    let s = Math.floor(remTime / 1000);
+    let m = Math.floor(s / 60);
+    let h = Math.floor(m / 60);
+    let d = Math.floor(h / 24);
 
-  if(document.querySelector('#to-thanksgiving-days') != null) {
-    document.querySelector('#to-thanksgiving-days').textContent = d;
+    h %= 24;
+    m %= 60;
+    s %= 60;
+
+    h = h < 10 ? '0' + h : h;
+    m = m < 10 ? '0' + m : m;
+    s = s < 10 ? '0' + s : s;
+
+    if (document.querySelector('#to-thanksgiving-days') != null) {
+      document.querySelector('#to-thanksgiving-days').textContent = d;
+    }
+    if (document.querySelector('#to-thanksgiving-hours') != null) {
+      document.querySelector('#to-thanksgiving-hours').textContent = h;
+    }
+    if (document.querySelector('#to-thanksgiving-minutes') != null) {
+      document.querySelector('#to-thanksgiving-minutes').textContent = m;
+    }
+    if (document.querySelector('#to-thanksgiving-seconds') != null) {
+      document.querySelector('#to-thanksgiving-seconds').textContent = s;
+    }
+
+    setTimeout(tick, 1000);
   }
-  if(document.querySelector('#to-thanksgiving-hours') != null) {
-    document.querySelector('#to-thanksgiving-hours').textContent = h;
-  }
-  if(document.querySelector('#to-thanksgiving-minutes') != null) {
-    document.querySelector('#to-thanksgiving-minutes').textContent = m;
-  }
-  if(document.querySelector('#to-thanksgiving-seconds') != null) {
-    document.querySelector('#to-thanksgiving-seconds').textContent = s;
-  }
 
-  setTimeout(countdown, 1000)
-};
-
-// Calculate the 4th Thursday of November for a given year
-function getThanksgiving(year) {
-  // Start with November 1st
-  let november = new Date(year, 10, 1);
-  // Find the first Thursday (day 4)
-  let dayOfWeek = november.getDay();
-  let firstThursday = 1 + ((4 - dayOfWeek + 7) % 7);
-  // 4th Thursday is 3 weeks later
-  let fourthThursday = firstThursday + 21;
-  return new Date(year, 10, fourthThursday);
-}
-
-countdown();
+  tick();
+})();


### PR DESCRIPTION
## Summary
Stability fixes for the holiday countdown and dynamic-menu scripts:

- IIFE-wrap each script so the three holiday countdowns no longer overwrite each other through a shared `function countdown` global. Enabling Christmas + Halloween + Thanksgiving on the same page now works.
- Roll holiday countdowns over to next year only after the holiday day has fully passed, and clamp remaining time to zero — visitors on the day-of see `0d 00:00:00` instead of "365 days to next Halloween".
- Guard `dynamicMenu.js` against a missing `.active` tab or `.rf_menu__border` element.
- Declare the snow loop counter with `let` so `i` no longer leaks onto `window`.

DOM contract is unchanged — existing customer pages keep working with no edits.

## Test plan
- [ ] Load a viewer page with both `christmasCountdown.js` and `halloweenCountdown.js` enabled; confirm both countdowns tick once per second simultaneously.
- [ ] Set the system clock to Dec 25 (and Oct 31, and the 4th Thursday of November) and confirm each countdown shows `0d 00:00:00` rather than ~365 days. At midnight the day after, confirm it flips to next year's holiday.
- [ ] Load `dynamicMenu.js` on a page that has `.rf_menu` but no `.active` tab — confirm no console errors and the rest of the page works.
- [ ] Smoke `customCountdown.js` with both `data-target="2026-12-31T23:59:59"` and `data-target="18:00"`; verify it ticks down normally and the daily form rolls to tomorrow after the target time.
- [ ] Open a fresh page; confirm `window.countdown` and `window.i` are `undefined` (no global pollution).