### PR TITLE
fix: harden scripts against double-injection, hidden tabs, and bad input

### DIFF
--- a/christmasCountdown.js
+++ b/christmasCountdown.js
@@ -1,7 +1,12 @@
 (function () {
   'use strict';
 
-  function tick() {
+  if (window.__rfChristmasCountdown) return;
+  window.__rfChristmasCountdown = true;
+
+  let elDays, elHours, elMinutes, elSeconds;
+
+  function update() {
     let now = new Date();
     let year = now.getFullYear();
     let evenDate = new Date(year, 11, 25);
@@ -28,21 +33,34 @@
     m = m < 10 ? '0' + m : m;
     s = s < 10 ? '0' + s : s;
 
-    if (document.querySelector('#to-christmas-days') != null) {
-      document.querySelector('#to-christmas-days').textContent = d;
-    }
-    if (document.querySelector('#to-christmas-hours') != null) {
-      document.querySelector('#to-christmas-hours').textContent = h;
-    }
-    if (document.querySelector('#to-christmas-minutes') != null) {
-      document.querySelector('#to-christmas-minutes').textContent = m;
-    }
-    if (document.querySelector('#to-christmas-seconds') != null) {
-      document.querySelector('#to-christmas-seconds').textContent = s;
-    }
-
-    setTimeout(tick, 1000);
+    if (elDays) elDays.textContent = d;
+    if (elHours) elHours.textContent = h;
+    if (elMinutes) elMinutes.textContent = m;
+    if (elSeconds) elSeconds.textContent = s;
   }
 
-  tick();
+  function loop() {
+    if (!document.hidden) update();
+    setTimeout(loop, 1000);
+  }
+
+  function start() {
+    elDays = document.querySelector('#to-christmas-days');
+    elHours = document.querySelector('#to-christmas-hours');
+    elMinutes = document.querySelector('#to-christmas-minutes');
+    elSeconds = document.querySelector('#to-christmas-seconds');
+
+    document.addEventListener('visibilitychange', () => {
+      if (!document.hidden) update();
+    });
+
+    update();
+    loop();
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', start);
+  } else {
+    start();
+  }
 })();

--- a/customCountdown.js
+++ b/customCountdown.js
@@ -1,14 +1,19 @@
 (function () {
   'use strict';
 
-  function tick() {
-    let container = document.querySelector('#custom-countdown');
-    if (container == null) {
-      return;
-    }
+  if (window.__rfCustomCountdown) return;
+  window.__rfCustomCountdown = true;
 
-    let targetValue = container.getAttribute('data-target');
+  let container, elDays, elHours, elMinutes, elSeconds;
+  let warned = false;
+
+  function update() {
+    const targetValue = container.getAttribute('data-target');
     if (targetValue == null) {
+      if (!warned) {
+        console.warn('[remote-falcon] custom-countdown: missing data-target attribute');
+        warned = true;
+      }
       return;
     }
 
@@ -33,18 +38,19 @@
       // Specific date/time format
       evenDate = new Date(targetValue);
 
-      // If invalid date, exit
       if (isNaN(evenDate.getTime())) {
+        if (!warned) {
+          console.warn('[remote-falcon] custom-countdown: invalid data-target', targetValue);
+          warned = true;
+        }
         return;
       }
     }
 
-    let remTime = evenDate.getTime() - now.getTime();
+    warned = false;
 
-    // If the target has passed (for non-recurring), show zeros
-    if (remTime < 0) {
-      remTime = 0;
-    }
+    let remTime = evenDate.getTime() - now.getTime();
+    if (remTime < 0) remTime = 0;
 
     let s = Math.floor(remTime / 1000);
     let m = Math.floor(s / 60);
@@ -59,21 +65,40 @@
     m = m < 10 ? '0' + m : m;
     s = s < 10 ? '0' + s : s;
 
-    if (document.querySelector('#custom-countdown-days') != null) {
-      document.querySelector('#custom-countdown-days').textContent = d;
-    }
-    if (document.querySelector('#custom-countdown-hours') != null) {
-      document.querySelector('#custom-countdown-hours').textContent = h;
-    }
-    if (document.querySelector('#custom-countdown-minutes') != null) {
-      document.querySelector('#custom-countdown-minutes').textContent = m;
-    }
-    if (document.querySelector('#custom-countdown-seconds') != null) {
-      document.querySelector('#custom-countdown-seconds').textContent = s;
-    }
-
-    setTimeout(tick, 1000);
+    if (elDays) elDays.textContent = d;
+    if (elHours) elHours.textContent = h;
+    if (elMinutes) elMinutes.textContent = m;
+    if (elSeconds) elSeconds.textContent = s;
   }
 
-  tick();
+  function loop() {
+    if (!document.hidden) update();
+    setTimeout(loop, 1000);
+  }
+
+  function start() {
+    container = document.querySelector('#custom-countdown');
+    if (container == null) {
+      console.warn('[remote-falcon] custom-countdown: missing #custom-countdown container');
+      return;
+    }
+
+    elDays = document.querySelector('#custom-countdown-days');
+    elHours = document.querySelector('#custom-countdown-hours');
+    elMinutes = document.querySelector('#custom-countdown-minutes');
+    elSeconds = document.querySelector('#custom-countdown-seconds');
+
+    document.addEventListener('visibilitychange', () => {
+      if (!document.hidden) update();
+    });
+
+    update();
+    loop();
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', start);
+  } else {
+    start();
+  }
 })();

--- a/dynamicMenu.js
+++ b/dynamicMenu.js
@@ -1,49 +1,65 @@
 (function () {
   'use strict';
 
-  const rf_menu = document.body && document.body.querySelector(".rf_menu");
-  if (!rf_menu) return;
+  if (window.__rfDynamicMenu) return;
+  window.__rfDynamicMenu = true;
 
-  const menuItems = rf_menu.querySelectorAll(".rf_menu__item");
-  const menuBorder = rf_menu.querySelector(".rf_menu__border");
-  let activeItem = rf_menu.querySelector(".active");
+  function start() {
+    const rf_menu = document.body.querySelector(".rf_menu");
+    if (!rf_menu) return;
 
-  if (!activeItem || !menuBorder) return;
+    const menuItems = rf_menu.querySelectorAll(".rf_menu__item");
+    const menuBorder = rf_menu.querySelector(".rf_menu__border");
+    let activeItem = rf_menu.querySelector(".active");
 
-  function clickItem(item, index) {
-    if (activeItem === item) return;
+    if (!activeItem || !menuBorder) return;
 
-    if (activeItem) {
-      activeItem.classList.remove("active");
+    function clickItem(item, index) {
+      if (activeItem === item) return;
+
+      if (activeItem) {
+        activeItem.classList.remove("active");
+      }
+
+      item.classList.add("active");
+      activeItem = item;
+      showTab(index);
+      offsetMenuBorder(activeItem, menuBorder);
     }
 
-    item.classList.add("active");
-    activeItem = item;
-    showTab(index);
-    offsetMenuBorder(activeItem, menuBorder);
-  }
+    function showTab(index) {
+      const bodies = document.querySelectorAll('.content__body');
+      bodies.forEach((body, i) => {
+        body.classList.toggle('active', i === index);
+      });
+    }
 
-  function showTab(index) {
-    const bodies = document.querySelectorAll('.content__body');
-    bodies.forEach((body, i) => {
-      body.classList.toggle('active', i === index);
+    function offsetMenuBorder(element, menuBorder) {
+      const offsetActiveItem = element.getBoundingClientRect();
+      const left = Math.floor(offsetActiveItem.left - rf_menu.offsetLeft - (menuBorder.offsetWidth - offsetActiveItem.width) / 2) + "px";
+      menuBorder.style.transform = `translate3d(${left}, 0 , 0)`;
+    }
+
+    offsetMenuBorder(activeItem, menuBorder);
+
+    menuItems.forEach((item, index) => {
+      item.addEventListener("click", () => clickItem(item, index));
+    });
+
+    let resizeRaf = 0;
+    window.addEventListener("resize", () => {
+      if (resizeRaf) return;
+      resizeRaf = requestAnimationFrame(() => {
+        resizeRaf = 0;
+        offsetMenuBorder(activeItem, menuBorder);
+        rf_menu.style.setProperty("--timeOut", "none");
+      });
     });
   }
 
-  function offsetMenuBorder(element, menuBorder) {
-    const offsetActiveItem = element.getBoundingClientRect();
-    const left = Math.floor(offsetActiveItem.left - rf_menu.offsetLeft - (menuBorder.offsetWidth - offsetActiveItem.width) / 2) + "px";
-    menuBorder.style.transform = `translate3d(${left}, 0 , 0)`;
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', start);
+  } else {
+    start();
   }
-
-  offsetMenuBorder(activeItem, menuBorder);
-
-  menuItems.forEach((item, index) => {
-    item.addEventListener("click", () => clickItem(item, index));
-  });
-
-  window.addEventListener("resize", () => {
-    offsetMenuBorder(activeItem, menuBorder);
-    rf_menu.style.setProperty("--timeOut", "none");
-  });
 })();

--- a/halloweenCountdown.js
+++ b/halloweenCountdown.js
@@ -1,7 +1,12 @@
 (function () {
   'use strict';
 
-  function tick() {
+  if (window.__rfHalloweenCountdown) return;
+  window.__rfHalloweenCountdown = true;
+
+  let elDays, elHours, elMinutes, elSeconds;
+
+  function update() {
     let now = new Date();
     let year = now.getFullYear();
     let evenDate = new Date(year, 9, 31); // October 31
@@ -28,21 +33,34 @@
     m = m < 10 ? '0' + m : m;
     s = s < 10 ? '0' + s : s;
 
-    if (document.querySelector('#to-halloween-days') != null) {
-      document.querySelector('#to-halloween-days').textContent = d;
-    }
-    if (document.querySelector('#to-halloween-hours') != null) {
-      document.querySelector('#to-halloween-hours').textContent = h;
-    }
-    if (document.querySelector('#to-halloween-minutes') != null) {
-      document.querySelector('#to-halloween-minutes').textContent = m;
-    }
-    if (document.querySelector('#to-halloween-seconds') != null) {
-      document.querySelector('#to-halloween-seconds').textContent = s;
-    }
-
-    setTimeout(tick, 1000);
+    if (elDays) elDays.textContent = d;
+    if (elHours) elHours.textContent = h;
+    if (elMinutes) elMinutes.textContent = m;
+    if (elSeconds) elSeconds.textContent = s;
   }
 
-  tick();
+  function loop() {
+    if (!document.hidden) update();
+    setTimeout(loop, 1000);
+  }
+
+  function start() {
+    elDays = document.querySelector('#to-halloween-days');
+    elHours = document.querySelector('#to-halloween-hours');
+    elMinutes = document.querySelector('#to-halloween-minutes');
+    elSeconds = document.querySelector('#to-halloween-seconds');
+
+    document.addEventListener('visibilitychange', () => {
+      if (!document.hidden) update();
+    });
+
+    update();
+    loop();
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', start);
+  } else {
+    start();
+  }
 })();

--- a/makeItSnow.js
+++ b/makeItSnow.js
@@ -1,69 +1,78 @@
 // widget by Embed.im (Licenses & Credits: https://app.embed.im/licenses.txt)
-var embedimSnow = document.getElementById("embedim--snow");
-if (!embedimSnow) {
-  let embRand2 = function (min, max) {
+(function () {
+  'use strict';
+
+  function start() {
+    if (document.getElementById("embedim--snow")) return;
+
+    function embRand2(min, max) {
       return Math.floor(Math.random() * (max - min + 1)) + min;
-    },
-    embRandColor2 = function () {
+    }
+    function embRandColor2() {
       var items = [
         "radial-gradient(circle at top left,#dcf2fd,#60b4f2)",
         "#dbf2fd",
         "#d8f8ff",
         "#b8ddfa",
       ];
-      var item = items[Math.floor(Math.random() * items.length)];
-      return item;
-    };
-  var embRand = embRand2,
-    embRandColor = embRandColor2;
-  var embCSS =
-    ".embedim-snow{position: absolute;width: 10px;height: 10px;background: white;border-radius: 50%;margin-top:-10px}";
-  var embHTML = "";
-  for (let i = 1; i < 200; i++) {
-    embHTML += '<i class="embedim-snow"></i>';
-    var rndX = embRand2(0, 1e6) * 1e-4,
-      rndO = embRand2(-1e5, 1e5) * 1e-4,
-      rndT = (embRand2(3, 8) * 10).toFixed(2),
-      rndS = (embRand2(0, 1e4) * 1e-4).toFixed(2);
-    embCSS +=
-      ".embedim-snow:nth-child(" +
-      i +
-      "){background:" +
-      embRandColor2() +
-      ";opacity:" +
-      (embRand2(1, 1e4) * 1e-4).toFixed(2) +
-      ";transform:translate(" +
-      rndX.toFixed(2) +
-      "vw,-10px) scale(" +
-      rndS +
-      ");animation:fall-" +
-      i +
-      " " +
-      embRand2(10, 30) +
-      "s -" +
-      embRand2(0, 30) +
-      "s linear infinite}@keyframes fall-" +
-      i +
-      "{" +
-      rndT +
-      "%{transform:translate(" +
-      (rndX + rndO).toFixed(2) +
-      "vw," +
-      rndT +
-      "vh) scale(" +
-      rndS +
-      ")}to{transform:translate(" +
-      (rndX + rndO / 2).toFixed(2) +
-      "vw, 105vh) scale(" +
-      rndS +
-      ")}}";
+      return items[Math.floor(Math.random() * items.length)];
+    }
+
+    var embCSS =
+      ".embedim-snow{position: absolute;width: 10px;height: 10px;background: white;border-radius: 50%;margin-top:-10px}";
+    var embHTML = "";
+    for (let i = 1; i < 200; i++) {
+      embHTML += '<i class="embedim-snow"></i>';
+      var rndX = embRand2(0, 1e6) * 1e-4,
+        rndO = embRand2(-1e5, 1e5) * 1e-4,
+        rndT = (embRand2(3, 8) * 10).toFixed(2),
+        rndS = (embRand2(0, 1e4) * 1e-4).toFixed(2);
+      embCSS +=
+        ".embedim-snow:nth-child(" +
+        i +
+        "){background:" +
+        embRandColor2() +
+        ";opacity:" +
+        (embRand2(1, 1e4) * 1e-4).toFixed(2) +
+        ";transform:translate(" +
+        rndX.toFixed(2) +
+        "vw,-10px) scale(" +
+        rndS +
+        ");animation:fall-" +
+        i +
+        " " +
+        embRand2(10, 30) +
+        "s -" +
+        embRand2(0, 30) +
+        "s linear infinite}@keyframes fall-" +
+        i +
+        "{" +
+        rndT +
+        "%{transform:translate(" +
+        (rndX + rndO).toFixed(2) +
+        "vw," +
+        rndT +
+        "vh) scale(" +
+        rndS +
+        ")}to{transform:translate(" +
+        (rndX + rndO / 2).toFixed(2) +
+        "vw, 105vh) scale(" +
+        rndS +
+        ")}}";
+    }
+    var embedimSnow = document.createElement("div");
+    embedimSnow.id = "embedim--snow";
+    embedimSnow.innerHTML =
+      "<style>#embedim--snow{position:fixed;left:0;top:0;bottom:0;width:100vw;height:100vh;overflow:hidden;z-index:9999999;pointer-events:none}" +
+      embCSS +
+      "</style>" +
+      embHTML;
+    document.body.appendChild(embedimSnow);
   }
-  embedimSnow = document.createElement("div");
-  embedimSnow.id = "embedim--snow";
-  embedimSnow.innerHTML =
-    "<style>#embedim--snow{position:fixed;left:0;top:0;bottom:0;width:100vw;height:100vh;overflow:hidden;z-index:9999999;pointer-events:none}" +
-    embCSS +
-    "</style>" +
-    embHTML;
-  document.body.appendChild(embedimSnow);
-}
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', start);
+  } else {
+    start();
+  }
+})();

--- a/thanksgivingCountdown.js
+++ b/thanksgivingCountdown.js
@@ -1,6 +1,11 @@
 (function () {
   'use strict';
 
+  if (window.__rfThanksgivingCountdown) return;
+  window.__rfThanksgivingCountdown = true;
+
+  let elDays, elHours, elMinutes, elSeconds;
+
   // Calculate the 4th Thursday of November for a given year
   function getThanksgiving(year) {
     let november = new Date(year, 10, 1);
@@ -10,7 +15,7 @@
     return new Date(year, 10, fourthThursday);
   }
 
-  function tick() {
+  function update() {
     let now = new Date();
     let year = now.getFullYear();
     let evenDate = getThanksgiving(year);
@@ -38,21 +43,34 @@
     m = m < 10 ? '0' + m : m;
     s = s < 10 ? '0' + s : s;
 
-    if (document.querySelector('#to-thanksgiving-days') != null) {
-      document.querySelector('#to-thanksgiving-days').textContent = d;
-    }
-    if (document.querySelector('#to-thanksgiving-hours') != null) {
-      document.querySelector('#to-thanksgiving-hours').textContent = h;
-    }
-    if (document.querySelector('#to-thanksgiving-minutes') != null) {
-      document.querySelector('#to-thanksgiving-minutes').textContent = m;
-    }
-    if (document.querySelector('#to-thanksgiving-seconds') != null) {
-      document.querySelector('#to-thanksgiving-seconds').textContent = s;
-    }
-
-    setTimeout(tick, 1000);
+    if (elDays) elDays.textContent = d;
+    if (elHours) elHours.textContent = h;
+    if (elMinutes) elMinutes.textContent = m;
+    if (elSeconds) elSeconds.textContent = s;
   }
 
-  tick();
+  function loop() {
+    if (!document.hidden) update();
+    setTimeout(loop, 1000);
+  }
+
+  function start() {
+    elDays = document.querySelector('#to-thanksgiving-days');
+    elHours = document.querySelector('#to-thanksgiving-hours');
+    elMinutes = document.querySelector('#to-thanksgiving-minutes');
+    elSeconds = document.querySelector('#to-thanksgiving-seconds');
+
+    document.addEventListener('visibilitychange', () => {
+      if (!document.hidden) update();
+    });
+
+    update();
+    loop();
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', start);
+  } else {
+    start();
+  }
 })();


### PR DESCRIPTION
Stacks on top of #4. Retargets to `main` automatically when #4 merges.

## Summary
Hardening pass over the same six scripts:

- **Idempotency** — each script now sets a `window.__rf*` sentinel and bails if it has already run, so accidentally injecting the script tag twice no longer stacks timers and resize listeners. `makeItSnow.js` keeps its existing element check.
- **Cache + visibility pause** — countdown scripts cache their four display elements once at startup instead of re-querying every tick, skip display work when `document.hidden` is true, and force an immediate refresh on `visibilitychange` so the user sees the right value the instant they refocus the tab.
- **Resize throttle** — `dynamicMenu.js` wraps its resize handler in `requestAnimationFrame` to avoid layout thrash on mobile rotation and window drags.
- **Better error feedback** — `customCountdown.js` now `console.warn`s when the container is missing, the `data-target` attribute is missing, or the date is unparseable. Warnings dedupe so a misconfigured page does not spam the console once per second.
- **DOM-ready guard** — every script now defers initialization until `DOMContentLoaded`, so dropping the tag in `<head>` without `defer`/`async` works correctly.

DOM contract is unchanged.

## Test plan
- [ ] Inject `christmasCountdown.js` twice on the same page; confirm only one timer is running (no doubled tick rate, no doubled display flicker).
- [ ] Open a viewer page with `customCountdown.js` and a missing `data-target`; confirm exactly one `console.warn` and no spam.
- [ ] Set `data-target="not-a-date"`; confirm one warn and no thrown errors.
- [ ] Hide the tab for 30 seconds, reveal — countdown should show the correct current time immediately, not the value from when the tab was hidden.
- [ ] Move the script tag into `<head>` (no `defer`); confirm the countdown still initializes after page load.
- [ ] Resize the browser window rapidly with `dynamicMenu.js` enabled; confirm the menu border keeps up but DevTools Performance shows no continuous layout/style thrash.