### PR TITLE
chore: add lint CI and release/SRI workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,23 @@
+name: Lint
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  syntax-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Syntax-check every script in scripts.json
+        run: |
+          set -e
+          for name in $(jq -r '.[]' scripts.json); do
+            file="${name}.js"
+            echo "node --check ${file}"
+            node --check "${file}"
+          done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,43 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  publish-release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Compute SRI hashes for every script in scripts.json
+        run: |
+          set -e
+          {
+            echo "## Subresource Integrity"
+            echo ""
+            echo "When embedding these scripts, pin the version in the URL and add the matching \`integrity\` attribute:"
+            echo ""
+            echo '```html'
+            echo '<script src="https://<cdn>/<path>/${{ github.ref_name }}/<script>.js"'
+            echo '        integrity="<sha384-hash from below>"'
+            echo '        crossorigin="anonymous"></script>'
+            echo '```'
+            echo ""
+            echo '| Script | SRI hash |'
+            echo '|---|---|'
+            for name in $(jq -r '.[]' scripts.json); do
+              file="${name}.js"
+              hash="sha384-$(openssl dgst -sha384 -binary "${file}" | base64 -w0)"
+              echo "| \`${file}\` | \`${hash}\` |"
+            done
+          } > release-notes.md
+          cat release-notes.md
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release create "${GITHUB_REF_NAME}" --notes-file release-notes.md --title "${GITHUB_REF_NAME}"

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
    4. [Thanksgiving Countdown](#thanksgiving-countdown)
    5. [Custom Countdown](#custom-countdown)
    6. [Dynamic Menu](#dynamic-menu)
+4. [For Integrators](#for-integrators)
 # Script Guidelines
 Before submitting your scripts for use with Remote Falcon, there are some general
 guidelines that need to be followed. If not followed properly, it could result in the 
@@ -548,7 +549,11 @@ Add the below to your <head> section
 	#
 	
 </style>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.6.0/css/all.min.css">
+<link rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.6.0/css/all.min.css"
+      integrity="sha512-Kc323vGBEqzTmouAECnVceyQqyqdsSiqLQISBL29aUW4U/M7pSPA/gEUZQqv1cwx4OnYxTxve5UMg5GT6L4JJg=="
+      crossorigin="anonymous"
+      referrerpolicy="no-referrer">
 ```
 
 Next inside the <body> tag will be the below HTML.  
@@ -608,3 +613,17 @@ You may need to buffer the bottom of some tabs with extra lines to prevent the m
 </div>
 
 ```
+
+# For Integrators
+
+These scripts are served as static files via CDN. Whoever embeds them in a viewer page (the Remote Falcon platform itself, or a self-hosted equivalent) should:
+
+1. **Pin the version.** Reference a tagged release URL rather than `main`. Each tag publishes a GitHub Release containing the SRI hash for every script — see [Releases](https://github.com/Remote-Falcon/remote-falcon-viewer-page-js/releases).
+2. **Add `integrity` and `crossorigin="anonymous"`** to each `<script>` tag using the published SRI hash. This protects viewer pages if the CDN distribution layer is ever compromised.
+   ```html
+   <script src="https://<cdn>/<path>/v1.2.0/makeItSnow.js"
+           integrity="sha384-…"
+           crossorigin="anonymous"
+           defer></script>
+   ```
+3. **Use `defer`** (or place the tag immediately before `</body>`). The scripts initialize on `DOMContentLoaded` and tolerate either placement, but `defer` keeps the HTML parser unblocked.


### PR DESCRIPTION
Final piece of the audit follow-up (after #4 and #5).

## Summary
Closes the operational gaps from the audit:

- **Lint CI** — `.github/workflows/lint.yml` runs `node --check` over every script listed in `scripts.json` on every push and pull request, so syntax errors fail PRs before they can ship to customer pages.
- **Release + SRI workflow** — `.github/workflows/release.yml` fires on `v*` tag pushes, computes a `sha384` SRI hash for every script, and creates a GitHub Release with the hashes in the body so integrators can pin both version and integrity.
- **README** — adds an SRI hash to the documented Font Awesome 6.6.0 `<link>` snippet, plus a new "For Integrators" section covering version pinning, `integrity` / `crossorigin`, and `defer`.

After merge, push a tag (e.g., `v1.0.0`) to cut the first SRI-published release. The release workflow uses the default `GITHUB_TOKEN`; no extra secrets needed.

## Test plan
- [ ] After merge, open a throwaway PR that introduces a deliberate syntax error in one script — confirm the Lint workflow fails and blocks merge.
- [ ] Push a `v0.0.1-test` tag — confirm the Release workflow runs and creates a Release whose notes contain a row per script with a `sha384-…` hash.
- [ ] Compare a hash from the generated release notes to a locally-computed hash:
  ```bash
  openssl dgst -sha384 -binary makeItSnow.js | base64
  ```
  to verify they match.
- [ ] Render the README on GitHub and confirm the new "For Integrators" section appears in the table of contents and the Font Awesome `<link>` shows the integrity attributes.
- [ ] Delete the test tag/release once verified.