### PR TITLE
chore: bump GitHub Actions to v6 and pin Node 22

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,10 +9,10 @@ jobs:
   syntax-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
       - name: Syntax-check every script in scripts.json
         run: |
           set -e

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Compute SRI hashes for every script in scripts.json
         run: |


### PR DESCRIPTION
## Summary
Clears the Node.js 20 deprecation warning that surfaced on the `v1.0.0` Release workflow run, and modernizes the lint runtime.

- `actions/checkout` v4 → v6 (both `lint.yml` and `release.yml`)
- `actions/setup-node` v4 → v6
- Lint workflow's `node-version` 20 → 22 (Node 20 went EOL 2026-04-30; 22 is current Active LTS)

GitHub will force Node-24-runtime actions as the default on 2026-06-02 and remove the Node 20 runner support on 2026-09-16, so this is the timely fix.

## Test plan
- [ ] After merge, confirm a fresh PR triggers Lint and the run completes successfully on Node 22 with no deprecation annotations.
- [ ] Push a throwaway tag like `v1.0.1-test`, confirm Release workflow runs cleanly with no Node 20 warning, then delete the test tag/release.